### PR TITLE
Replace deprecated buffer constructors

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ Carlos Galveias.
 */
 
 /*
-  d3des.c translated to JavaScript 
+  d3des.c translated to JavaScript
   Andrey Sidorov <andrey.sidorov@gmail.com>
 */
 
@@ -67,8 +67,8 @@ var pc2 = [
 
 function deskey(key, edf) {
     var i, j, l, m, n;
-    var pc1m = new Buffer(56);
-    var pcr = new Buffer(56);
+    var pc1m = Buffer.alloc(56);
+    var pcr = Buffer.alloc(56);
     var kn = new Array(32);
 
     for (j = 0; j < 56; j++) {
@@ -401,10 +401,9 @@ function desfunc(block, keys) {
 
 
 module.exports.encrypt = function(password) {
-    var key = new Buffer(8);
-    key.fill(0);
+    var key = Buffer.alloc(8);
     key.write(password.substring(0, 8));
-    var res = new Buffer(8);
+    var res = Buffer.alloc(8);
     deskey(challenge, EN0);
     des(key, res);
     return { buffer: res, string: res.toString('hex') };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tightvnc-password-encrypt",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "From a plain password generates a TightVNC Server hex encrypted password",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This changes the buffers to be created with the `alloc` method, as their constructor has been deprecated from v10 onwards.

Migration was performed based on official nodejs documentation:

https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/